### PR TITLE
Fixed \Apps\Modules\Acme\BootStrap class not found

### DIFF
--- a/src/Apps/Modules/Acme/BootStrap.php
+++ b/src/Apps/Modules/Acme/BootStrap.php
@@ -8,7 +8,7 @@ if (!defined('CF_SYSTEM')) {
     exit('External script access not allowed');
 }
 
-class Bootstrap
+class BootStrap
 {
     /**
      * You can register events or data into container

--- a/src/Apps/Modules/Demo/BootStrap.php
+++ b/src/Apps/Modules/Demo/BootStrap.php
@@ -8,7 +8,7 @@ if (!defined('CF_SYSTEM')) {
     exit('External script access not allowed');
 }
 
-class Bootstrap
+class BootStrap
 {
     /**
      * You can register events or data into container


### PR DESCRIPTION
Fixed \Apps\Modules\Acme\BootStrap class not found